### PR TITLE
opening google map in an external app

### DIFF
--- a/www/js/application.js
+++ b/www/js/application.js
@@ -400,7 +400,7 @@ function getDirections( index ) {
         else 
         */
         if (android) {
-            navigator.app.loadUrl( 'http://maps.google.com/maps?q=' + market.y + ',' + market.x);
+            navigator.app.loadUrl( 'http://maps.google.com/maps?q=' + market.y + ',' + market.x, { openExternal:true});
         }
         else {
             window.open( ('http://maps.google.com/maps?q=' + market.y + ',' + market.x), '_blank' );


### PR DESCRIPTION
added a parameter to open the "Get directions" page in an external app, either the web browser or the google maps app. 
Without this change once opened the "Get directions" page I was stuck there with no possibility to go back to the other pages of the Fresh Food Finder app (maybe because of the override of the backbutton action...).

(Samsung Galaxy S, android 2.3.6)
